### PR TITLE
Use protocol relative URLs for external JS files

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,10 +188,10 @@ $(&quot;.diagram&quot;).sequenceDiagram({theme: &#39;hand&#39;});
       </div>
     </footer>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 
     <!-- Needed for the text editor -->
-    <script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="//d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
 
     <script src="underscore-min.js"></script>
     <script src="raphael-min.js"></script>


### PR DESCRIPTION
Right now if you access the Github pages URL over HTTPS, it doesn't work.