### PR TITLE
Avoid unintended global

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -15,6 +15,7 @@
 
 	Diagram.prototype.getActor = function(alias) {
 		var s = /^(.+) as (\S+)$/i.exec(alias.trim());
+		var name;
 		if (s) {
 			name  = s[1].trim();
 			alias = s[2].trim();


### PR DESCRIPTION
The `name` variable in `Diagram.prototype.getActor` is never declared, making it an unintended global. This fixes that.
