### PR TITLE
Removed incorrect semicolons from README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ and then
 
 or use jQuery to do all the work:
 ```html
-<div class="diagram">A->B: Message</div>;
-<script>;
+<div class="diagram">A->B: Message</div>
+<script>
 $(".diagram").sequenceDiagram({theme: 'hand'});
-</script>;
+</script>
 ```
 
 Build requirements


### PR DESCRIPTION
Thumbs up for your great plugin! :+1: 

But the semicolons at the end of the tags `</div>` and `</script>` are not needed.