### PR TITLE
Remove protocol from external script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,10 +188,10 @@ $(&quot;.diagram&quot;).sequenceDiagram({theme: &#39;hand&#39;});
       </div>
     </footer>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 
     <!-- Needed for the text editor -->
-    <script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="//d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
 
     <script src="underscore-min.js"></script>
     <script src="raphael-min.js"></script>


### PR DESCRIPTION
This is only for the Github Pages demo.

Allows external resources to be loaded if you're on `http` and `https`.

# Screenshot

![image](https://cloud.githubusercontent.com/assets/172217/6095391/e4b69070-af0f-11e4-87a2-2b025fbfde9c.png)

*Note blocked JS in the console.*