### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Many thanks to [Web Sequence Diagrams](http://www.websequencediagrams.com/) whic
 Related
 -------
 
-* [Web Sequence Diagrams](http://www.websequencediagrams.com/) Server side version with a commerical offering
+* [Web Sequence Diagrams](http://www.websequencediagrams.com/) Server side version with a commercial offering
 * [flowchart.js](http://adrai.github.io/flowchart.js/) A similar project that draws flow charts in the browser
 
 Licence (Simplified BSD License)


### PR DESCRIPTION
@bramp, I've corrected a typographical error in the documentation of the [js-sequence-diagrams](https://github.com/bramp/js-sequence-diagrams) project. Specifically, I've changed commerical to commercial. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.