### PR TITLE
Prevent warning about bad license name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/bramp/js-sequence-diagrams.git"
   },
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "devDependencies": {
     "jison": "0.4.15",
     "jshint": "2.7.x",


### PR DESCRIPTION
Fix a warning in NPM about the license name in package.json.

> npm WARN package.json js-sequence-diagrams@ license should be a valid SPDX
license expression