### PR TITLE
Add support for quoted actors with special chars.

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -89,7 +89,7 @@
 
 	Diagram.unescape = function(s) {
 		// Turn "\\n" into "\n"
-		return s.trim().replace(/\\n/gm, "\n");
+		return s.trim().replace(/^"(.*)"$/m, "$1").replace(/\\n/gm, "\n");
 	};
 
 	Diagram.LINETYPE = {

--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -23,7 +23,8 @@
 "note"            return 'note';
 "title"           return 'title';
 ","               return ',';
-[^\->:,\r\n]+     return 'ACTOR';
+[^\->:,\r\n"]+    return 'ACTOR';
+\"[^"]+\"         return 'ACTOR';
 "--"              return 'DOTLINE';
 "-"               return 'LINE';
 ">>"              return 'OPENARROW';

--- a/test/grammar-tests.js
+++ b/test/grammar-tests.js
@@ -181,6 +181,12 @@ test( "Newlines", function() {
 	assertSingleActor(Diagram.parse("Participant A\r\nNote left of A: Hello"), "A");
 });
 
+test( "Quoted names", function() {
+	assertSingleArrow(Diagram.parse("\"->:\"->B: M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "->:", "B", "M");
+	assertSingleArrow(Diagram.parse("A->\"->:\": M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "A", "->:", "M");
+	assertSingleActor(Diagram.parse("Participant \"->:\""), "->:");
+});
+
 test( "API", function() {
 	// Public API
 	ok(typeof Diagram.parse == "function");


### PR DESCRIPTION
This make possible to use special characters for actor names, but with this quotes will break actors.

I also need a way to handle quotes in quotes, and whitespace, but I wanted you to review as it is the first time I work in a parser.

This resolves #107.