### PR TITLE
Feature execution specifications

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -61,8 +61,6 @@
 		this.index = index;
 		this.executionSpecificationStack = [];
 		this.executionSpecifications = [];
-		// A value of -1 indicates that this actor/lifeline has no execution
-		// specifications.
 		this.maxExecutionSpecificationLevel = -1;
 	};
 
@@ -118,7 +116,8 @@
 				if (this.executionSpecificationStack.length >= 0) {
 					this.executionSpecificationStack.pop().setEndSignal(signal);
 				} else {
-					throw new Error("The execution specification level for actor " + this.name + " was dropped below 0.");
+					throw new Error("The execution specification level for actor " + this.name +
+					                " was dropped below 0.");
 				}
 				break;
 		}
@@ -126,24 +125,32 @@
 
 	/*
 	 * Returns the execution specification level for the actor at the point in
-	 * the sequence that the given signal is executed.
+	 * the sequence that the given signal is processed.
 	 */
 	Diagram.Actor.prototype.execSpecLevelAtSignal = function (signal) {
 		var level = -1;
-		_.each(this.executionSpecifications, function (e) {
+		_.each(this.executionSpecifications, function (e, i) {
 			if ((e.startSignal.index <= signal.index) &&
 					(e.endSignal === null || (e.endSignal.index >= signal.index))) {
-				level += 1;
+				level = Math.max(e.level, level);
 			}
 		});
 		return level;
 	};
 
+	/*
+	 * Returns the top level executionSpecification at the point in the sequence
+	 * that the given sequence is processed. Since the matching is inclusive, it
+	 * is used to identify if the signal is at the start or end of the
+	 * executionSpecification.
+	 */
 	Diagram.Actor.prototype.topExecSpecAtSignal = function (signal) {
 		var execSpec = null;
 		_.each(this.executionSpecifications, function (e) {
 			if ((e.startSignal.index <= signal.index) &&
-				(e.endSignal === null || (e.endSignal.index >= signal.index))) {
+			    (e.endSignal === null || (e.endSignal.index >= signal.index)) &&
+			    (execSpec === null || e.level >= execSpec.level))
+			{
 				execSpec = e;
 			}
 		});

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -15,7 +15,7 @@ statement ::=
 		( 'left of' | 'right of') actor
 		| 'over' (actor | actor ',' actor)
 		) ':' message
-	| actor ( '-' | '--' ) ( '>' | '>>' )? actor ':' message
+	| ( '-' | '+' )? actor ( '-' | '--' ) ( '>' | '>>' )? ( '-' | '+' )? actor ':' message
 	)
 
 /*

--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -23,11 +23,11 @@
 "note"            return 'note';
 "title"           return 'title';
 ","               return ',';
-[^\->:,\r\n"+]+    return 'ACTOR';
+[^\->:,\r\n"+]+   return 'ACTOR';
 \"[^"]+\"         return 'ACTOR';
 "--"              return 'DOTLINE';
 "-"               return 'LINE';
-"+"              return 'PLUS';
+"+"               return 'PLUS';
 ">>"              return 'OPENARROW';
 ">"               return 'ARROW';
 :[^\r\n]+         return 'MESSAGE';
@@ -82,7 +82,7 @@ signal
 	;
 
 execution_modifier
-	: /* empty */ { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.UNCHANGED}
+	: /* empty */ { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.UNCHANGED }
 	| LINE { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.DECREASE_LEVEL }
 	| PLUS { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.INCREASE_LEVEL }
 	;

--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -23,10 +23,11 @@
 "note"            return 'note';
 "title"           return 'title';
 ","               return ',';
-[^\->:,\r\n"]+    return 'ACTOR';
+[^\->:,\r\n"+]+    return 'ACTOR';
 \"[^"]+\"         return 'ACTOR';
 "--"              return 'DOTLINE';
 "-"               return 'LINE';
+"+"              return 'PLUS';
 ">>"              return 'OPENARROW';
 ">"               return 'ARROW';
 :[^\r\n]+         return 'MESSAGE';
@@ -76,8 +77,14 @@ placement
 	;
 
 signal
-	: actor signaltype actor message
-	{ $$ = new Diagram.Signal($1, $2, $3, $4); }
+	: execution_modifier actor signaltype execution_modifier actor message
+		{ $$ = new Diagram.Signal($2, $3, $5, $6, $1, $4); }
+	;
+
+execution_modifier
+	: /* empty */ { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.UNCHANGED}
+	| LINE { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.DECREASE_LEVEL }
+	| PLUS { $$ = Diagram.EXEC_SPEC_LVL_CHANGE.INCREASE_LEVEL }
 	;
 
 actor

--- a/src/sequence-diagram.js
+++ b/src/sequence-diagram.js
@@ -264,8 +264,8 @@
 
 			this.draw_title();
 			this.draw_actors(y);
+			this.draw_execution_specifications(y + this._actors_height);
 			this.draw_signals(y + this._actors_height);
-			this.draw_execution_specifications();
 
 			this._paper.setFinish();
 		},
@@ -456,8 +456,23 @@
 			this.draw_text_box(actor, actor.name, ACTOR_MARGIN, ACTOR_PADDING, this._font);
 		},
 
-		draw_execution_specifications : function () {
+		draw_execution_specifications : function (offsetY) {
+			var y = offsetY;
 			var self = this;
+
+			_.each(this.diagram.signals, function(s) {
+				if (s.type == "Signal") {
+					if (s.isSelf()) {
+						s.startY = y + SIGNAL_MARGIN;
+						s.endY = s.startY + s.height - SIGNAL_MARGIN;
+					} else {
+						s.startY = s.endY = y + s.height - SIGNAL_MARGIN - SIGNAL_PADDING;
+					}
+				}
+
+				y += s.height;
+			});
+
 			_.each(this.diagram.actors, function(a) {
 				self.draw_actors_execution_specifications(a);
 			});
@@ -538,9 +553,6 @@
 			line = this.draw_line(aX + SELF_SIGNAL_WIDTH, y2, x2, y2);
 			attr['arrow-end'] = this.arrow_types[signal.arrowtype] + '-wide-long';
 			line.attr(attr);
-
-			signal.startY = y1;
-			signal.endY = y2;
 		},
 
 		draw_signal : function (signal, offsetY) {
@@ -570,9 +582,6 @@
 				'arrow-end': this.arrow_types[signal.arrowtype] + '-wide-long',
 				'stroke-dasharray': this.line_types[signal.linetype]
 			});
-
-			signal.startY = y;
-			signal.endY = y;
 
 			//var ARROW_SIZE = 16;
 			//var dir = this.actorA.x < this.actorB.x ? 1 : -1;

--- a/src/sequence-diagram.js
+++ b/src/sequence-diagram.js
@@ -86,7 +86,7 @@
 	}
 
 /******************
- * Drawing related extra diagram methods.
+ * Drawing-related extra diagram methods.
  ******************/
 
 	Diagram.Actor.prototype.execSpecMarginLeft = function(signal) {
@@ -94,7 +94,8 @@
 		if (level < 0) {
 			return 0;
 		} else {
-			return -(EXECUTION_SPECIFICATION_WIDTH * 0.5) + level * OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET;
+			return -EXECUTION_SPECIFICATION_WIDTH * 0.5 +
+			       level * OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET;
 		}
 	};
 
@@ -103,7 +104,8 @@
 		if (level < 0) {
 			return 0;
 		} else {
-			return (EXECUTION_SPECIFICATION_WIDTH * 0.5) + level * OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET;
+			return EXECUTION_SPECIFICATION_WIDTH * 0.5 +
+			       level * OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET;
 		}
 	};
 
@@ -164,17 +166,14 @@
 	/**
 	 * Draws a wobbly (hand drawn) rect
 	 */
-	Raphael.fn.handRect = function (x, y, w, h, rect) {
+	Raphael.fn.handRect = function (x, y, w, h) {
 		assert(_.every([x, y, w, h], _.isFinite), "x, y, w, h must be numeric");
-		if (!rect) {
-			rect = RECT;
-		}
 		return this.path("M" + x + "," + y +
 			this.wobble(x, y, x + w, y) +
 			this.wobble(x + w, y, x + w, y + h) +
 			this.wobble(x + w, y + h, x, y + h) +
 			this.wobble(x, y + h, x, y))
-			.attr(rect);
+			.attr(RECT);
 	};
 
 	/**
@@ -310,7 +309,9 @@
 				a.distances = [];
 				a.padding_right = 0;
 				if (a.maxExecutionSpecificationLevel >= 0) {
-					a.padding_right = (EXECUTION_SPECIFICATION_WIDTH/2.0) + a.maxExecutionSpecificationLevel * OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET;
+					a.padding_right = (EXECUTION_SPECIFICATION_WIDTH / 2.0) +
+					                  (a.maxExecutionSpecificationLevel *
+					                   OVERLAPPING_EXECUTION_SPECIFICATION_OFFSET);
 				}
 				self._actors_height = Math.max(a.height, self._actors_height);
 			});
@@ -460,6 +461,7 @@
 			var y = offsetY;
 			var self = this;
 
+			// Calculate the y-positions of each signal before we attempt to draw the executionSpecificaitons.
 			_.each(this.diagram.signals, function(s) {
 				if (s.type == "Signal") {
 					if (s.isSelf()) {
@@ -488,7 +490,7 @@
 				var w = EXECUTION_SPECIFICATION_WIDTH;
 				var h = e.endSignal ? e.endSignal.startY - y : (actor.y - y);
 
-				// Draw inner box
+				// Draw actual execution specification.
 				var rect = self.draw_rect(x, y, w, h);
 				rect.attr(EXECUTION_SPECIFICATION_RECT);
 			});

--- a/test/grammar-tests.js
+++ b/test/grammar-tests.js
@@ -67,6 +67,13 @@ function assertEmptyDocument(d) {
 	equal(d.signals.length, 0, "Zero signals");
 }
 
+function testExecutionSpecification(execSpec, affectedActorName, startSignal, endSignal, level) {
+	equal(execSpec.actor.name, affectedActorName, "Correct actor");
+	equal(execSpec.startSignal, startSignal, "Start signal of ExecutionSpecification");
+	equal(execSpec.endSignal, endSignal, "End signal of ExecutionSpecification");
+	equal(execSpec.level, level, "Nesting level of ExecutionSpecification");
+}
+
 
 var LINETYPE = Diagram.LINETYPE;
 var ARROWTYPE = Diagram.ARROWTYPE;
@@ -185,6 +192,45 @@ test( "Quoted names", function() {
 	assertSingleArrow(Diagram.parse("\"->:\"->B: M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "->:", "B", "M");
 	assertSingleArrow(Diagram.parse("A->\"->:\": M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "A", "->:", "M");
 	assertSingleActor(Diagram.parse("Participant \"->:\""), "->:");
+	assertSingleArrow(Diagram.parse("A->\"+B\": M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "A", "+B", "M");
+	assertSingleArrow(Diagram.parse("\"+A\"->B: M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "+A", "B", "M");
+	assertSingleArrow(Diagram.parse("\"+A\"->\"+B\": M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "+A", "+B", "M");
+});
+
+test( "ExecutionSpecifications", function () {
+	assertSingleArrow(Diagram.parse("A->+B: M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "A", "B", "M");
+	assertSingleArrow(Diagram.parse("+A->B: M"), ARROWTYPE.FILLED, LINETYPE.SOLID, "A", "B", "M");
+	assertSingleArrow(Diagram.parse("+A-->+B: M"), ARROWTYPE.FILLED, LINETYPE.DOTTED, "A", "B", "M");
+	assertSingleArrow(Diagram.parse("+\"+A\"-->+B: M"), ARROWTYPE.FILLED, LINETYPE.DOTTED, "+A", "B", "M");
+
+	var d = Diagram.parse("A->+B: M1\n+B-->-B: M2\n-B-->>+A: M3");
+	equal(d.actors.length, 2, "Correct actors count");
+
+	var a = d.actors[0];
+	var b = d.actors[1];
+	equal(a.name, "A", "Actors A name");
+	equal(b.name, "B", "Actors B name");
+	var execSpecsA = a.executionSpecifications;
+	var execSpecsB = b.executionSpecifications;
+
+	equal(d.signals.length, 3, "Correct signals count");
+	equal(execSpecsA.length, 1, "Correct actor A ExecutionSpecification count");
+	equal(execSpecsB.length, 2, "Correct actor B ExecutionSpecification count");
+
+	// More or less normal ExecutionSpecification
+	testExecutionSpecification(execSpecsB[0], "B", d.signals[0], d.signals[2], 0);
+	// Self-signalled ExecutionSpecification
+	testExecutionSpecification(execSpecsB[1], "B", d.signals[1], d.signals[1], 1);
+	// Endless ExecutionSpecification
+	testExecutionSpecification(execSpecsA[0], "A", d.signals[2], null, 0);
+
+	// Make sure we haven't broken the different arrow types.
+	equal(d.signals[0].arrowtype, ARROWTYPE.FILLED, "Signal 1 Arrow Type");
+	equal(d.signals[0].linetype, LINETYPE.SOLID, "Signal 1 Line Type");
+	equal(d.signals[1].arrowtype, ARROWTYPE.FILLED, "Signal 2 Arrow Type");
+	equal(d.signals[1].linetype, LINETYPE.DOTTED, "Signal 2 Line Type");
+	equal(d.signals[2].arrowtype, ARROWTYPE.OPEN, "Signal 3 Arrow Type");
+	equal(d.signals[2].linetype, LINETYPE.DOTTED, "Signal 3 Line Type");
 });
 
 test( "API", function() {


### PR DESCRIPTION
I've added support for UML ExecutionSpecifications, which are the grey
bars commonly seen in UML Sequence Diagrams, and indicate the execution
of an action.

Using them is quite simple, all you need to do is prepend a `+` or `-`
character before the actor/lifeline that will be executing an action.
The `+` character will begin the ExecutionSpecification, and the `-`
character will end it.

Example
-------
The following example shows an API executing a function in response to
a user calling function foo().

    User->+API: foo()
    note right of API: Processing foo.
    -API-->User: Result.

Known Issues:
-------------
Doing a double jump in a single self-signal will cause some rendering issues. I don't expect this will be commonly encountered.

    +A->+A: This will cause some rendering issues regarding arrow placement.