### PR TITLE
README: recent versions of lodash not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ into
 
 Requirements
 ------------
-You will need [Raphaël](http://raphaeljs.com/), [underscore.js](http://underscorejs.org/) (or [lodash](https://lodash.com/)), and optionally [jQuery](https://jquery.com/).
+You will need [Raphaël](http://raphaeljs.com/), [underscore.js](http://underscorejs.org/) and optionally [jQuery](https://jquery.com/).
 
 
 Installation


### PR DESCRIPTION
Optionally,  lodash support could instead be fixed (see https://github.com/bramp/js-sequence-diagrams/issues/158)