### PR TITLE
Add actor specific class name

### DIFF
--- a/dist/sequence-diagram.js
+++ b/dist/sequence-diagram.js
@@ -1498,7 +1498,7 @@ if (typeof Snap != 'undefined') {
     drawActor: function(actor, offsetY, height) {
       this.beginGroup();
       BaseTheme.prototype.drawActor.call(this, actor, offsetY, height);
-      return this.finishGroup().addClass('actor');
+      return this.finishGroup().addClass('actor actor'+actor.index);
     },
 
     drawSignal: function(signal, offsetY) {


### PR DESCRIPTION
Allows CSS attributes to override individual actors.

Example to be used in `sequence-diagram.css`:
```
.actor0 text {
    fill: blue;
}
.actor0 rect, .actor0 path {
    fill: #9f9;
}
.actor1 rect, .actor1 path {
    fill: #f9f;
}
```
<img width="195" alt="screen shot 2017-06-04 at 2 48 33 pm" src="https://cloud.githubusercontent.com/assets/2746596/26765644/eedccddc-4934-11e7-8776-1da2cd5fc576.png">
<img width="217" alt="screen shot 2017-06-04 at 2 50 23 pm" src="https://cloud.githubusercontent.com/assets/2746596/26765652/30ba59ea-4935-11e7-8ef8-a755d355973f.png">

