### PR TITLE
Allow escape quotes characters in actor name

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -89,8 +89,11 @@ Diagram.Note.prototype.hasManyActors = function() {
 };
 
 Diagram.unescape = function(s) {
-  // Turn "\\n" into "\n"
-  return s.trim().replace(/^"(.*)"$/m, '$1').replace(/\\n/gm, '\n');
+  var unescaped = s.trim()
+    .replace(/^"(.*)"$/m, '$1') // remove quotes on quoted actors
+    .replace(/\\n/gm, '\n')     // turn "\\n" into "\n"
+    .replace(/\\"/gm, '"');     // turn '\"' into '"'
+  return unescaped;
 };
 
 Diagram.LINETYPE = {

--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -24,7 +24,7 @@
 "title"           return 'title';
 ","               return ',';
 [^\->:,\r\n"]+    return 'ACTOR';
-\"[^"]+\"         return 'ACTOR';
+\"(([^\"]|\\\")*[^\\])?\" return 'ACTOR'; // quoted actors
 "--"              return 'DOTLINE';
 "-"               return 'LINE';
 ">>"              return 'OPENARROW';

--- a/test/grammar-tests.js
+++ b/test/grammar-tests.js
@@ -191,6 +191,11 @@ test('Quoted names', function() {
   assertSingleActor(Diagram.parse('Participant "->:"'), '->:');
 });
 
+test('Quoted names with escape characters', function() {
+  assertSingleArrow(Diagram.parse('"->\\":"->B: M'), ARROWTYPE.FILLED, LINETYPE.SOLID,
+      '->":', 'B', 'M');
+});
+
 test('API', function() {
   // Public API
   ok(typeof Diagram.parse == 'function');


### PR DESCRIPTION
Make it possible to write almost anything as an actor name:

    "arrow-> and \"quotes\" in the actor name" -> bar : foo

I understand that it is not _super useful_ but this was a personal challenge :)