### PR TITLE
Improve syntax highlighting in the editor

### DIFF
--- a/src/mode-sequencebramp.js
+++ b/src/mode-sequencebramp.js
@@ -1,0 +1,56 @@
+define("ace/mode/sequencebramp_highlight_rules", ["require", "exports", "module", "ace/lib/oop"], function(e, t, n) {
+    "use strict";
+    var r = e("../lib/oop")
+      , i = e("./text_highlight_rules").TextHighlightRules
+      , s = function() {
+        function t(e) {
+            var t = /\w/.test(e) ? "\\b" : "(?:\\B|^)";
+            return t + e + "[^" + e + "].*?" + e + "(?![\\w*])"
+        }
+        this.$rules = {
+            start: [{
+                token: "comment",
+                regex: /^\s*#.*/
+            }, {
+                token: ["text", "string"],
+                regex: /^(\s*title:)(.*)/,
+		caseInsensitive: true,
+            }, {
+		// this doesn't handle commas well
+                token: ["text", "keyword", "text", "string"],
+                regex: /^(\s*note\s+(?:left\s+of|right\s+of|over)\s+)(.*)(:)(.*)/,
+		caseInsensitive: true,
+            }, {
+                token: ["text", "string", "text", "keyword"],
+                regex: /^(\s*participant\s+)(.*)(\bas\b)(.*)/,
+		caseInsensitive: true,
+            }, {
+                token: ["text", "keyword"],
+                regex: /^(\s*participant\s+)(.*)/,
+		caseInsensitive: true,
+            }, {
+                token: ["keyword", "operator", "keyword", "text", "string"],
+                regex: /^(\s*.*)(-?->>?)(.*)(\s*:\s*)(.*)?$/,
+	    },
+        ]};
+    };
+    r.inherits(s, i),
+    t.SequencebrampHighlightRules = s
+}),
+define("ace/mode/sequencebramp", ["require", "exports", "module", "ace/lib/oop", "ace/mode/text", "ace/mode/sequencebramp_highlight_rules", "ace/mode/folding/sequencebramp"],
+  function(e, t, n) {
+    "use strict";
+    var r = e("../lib/oop")
+      , i = e("./text").Mode
+      , s = e("./sequencebramp_highlight_rules").SequencebrampHighlightRules
+      , u = function() {
+        this.HighlightRules = s
+    };
+    r.inherits(u, i),
+    function() {
+        this.type = "text",
+        this.$id = "ace/mode/sequencebramp"
+    }
+    .call(u.prototype),
+    t.Mode = u
+})


### PR DESCRIPTION
Adds a highlighting mode to Ace for the sequence diagram language.

This is a bit nasty, a quick copy/paste/hack of asciidoc, but it makes the editor look a little better.

![image](https://user-images.githubusercontent.com/1245919/30008355-ffdbbc34-9172-11e7-8fe0-89e2e7ca9070.png)

It feels like this should be a PR on Ace instead, but I thought it might reach the people who need it better if it was part of js-sequence-diagrams.

To use it, put mode-sequencebramp.js in js/ace and change your index.html to `editor.getSession().setMode("ace/mode/sequencebramp");`