### PR TITLE
Add support for WebSequenceDiagrams title syntax

### DIFF
--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -9,7 +9,7 @@
 document ::= statement*
 
 statement ::=
-	( 'title' ':' message
+	( 'title' ':'? message
 	| 'participant' actor ('as' alias)?
 	| 'note' (
 		( 'left of' | 'right of') actor

--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -11,6 +11,8 @@
 	// Pre-lexer code can go here
 %}
 
+%x title
+
 %%
 
 [\r\n]+           return 'NL';
@@ -21,7 +23,8 @@
 "right of"        return 'right_of';
 "over"            return 'over';
 "note"            return 'note';
-"title"           return 'title';
+"title"           { this.begin('title'); return 'title'; }
+<title>[^\r\n]+   { this.popState(); return 'MESSAGE'; }
 ","               return ',';
 [^\->:,\r\n"]+    return 'ACTOR';
 \"[^"]+\"         return 'ACTOR';

--- a/test/grammar-tests.js
+++ b/test/grammar-tests.js
@@ -113,6 +113,8 @@ test('Dashed Open Arrow', function() {
 test('Titles', function() {
   equal(Diagram.parse('Title: title').title, 'title', 'Title');
   equal(Diagram.parse('Title: line1\\nline2').title, 'line1\nline2', 'Multiline Title');
+  equal(Diagram.parse('Title title').title, 'title', 'Title without colon');
+  equal(Diagram.parse('Title:: title').title, ': title', 'Title with multiple colons');
 });
 
 test('Unicode', function() {


### PR DESCRIPTION
In [WebSequenceDiagrams](https://www.websequencediagrams.com/), title messages aren't delimited by a `:`. This adds support for that using an exclusive start condition in the JISON grammar, while preserving backwards compatibility. I also added a couple tests.

I didn't commit the generated `dist/*.js` files so this is easier to review. Let me know if I should push those up.