### PR TITLE
Prevent text from overlapping lines

### DIFF
--- a/src/theme-snap.js
+++ b/src/theme-snap.js
@@ -215,6 +215,10 @@ if (typeof Snap != 'undefined') {
       t.attr({x: x - bb.x, y: y - bb.y});
       t.selectAll('tspan').attr({x: x});
 
+      // To prevent text from overlapping lines, add a white background by creating a rect without
+      // the stroke attribute.
+      this.drawRect(x, y, bb.width, bb.height).attr('stroke', 'none');
+
       this.pushToStack(t);
       return t;
     },


### PR DESCRIPTION
This adds a white background to text strings so that they're easier to read when crossing a line.

Before:
![screenshot_20181024_203643](https://user-images.githubusercontent.com/651224/47474728-2db67580-d7cd-11e8-9bf9-d70cc0cfbdaa.png)

After:
![screenshot_20181024_203535](https://user-images.githubusercontent.com/651224/47474727-2d1ddf00-d7cd-11e8-86eb-c7156ac92a55.png)

I didn't commit the `dist/*` file changes in order to make this easier to review. Let me know if I should and I'll push them up.
