### PR TITLE
Complete package.json to be usable by repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
+  - "8"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "js-sequence-diagrams",
+  "version": "2.0.1",
+  "main": "dist/sequence-diagram.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/bramp/js-sequence-diagrams.git"
   },
   "license": "BSD-2-Clause",
+  "dependencies": {
+    "underscore": "1.8.x",
+    "lodash": "4.17.x",
+    "raphael": "2.2.x",
+    "snapsvg": "0.4.x",
+    "webfontloader": "~1.6.x"
+  },
   "devDependencies": {
     "bower": "1.8.x",
     "eslint": "3.16.x",


### PR DESCRIPTION
In order to use the repository directly as dependency yarn as well as
npm require some details.

This patch adds the needed dependencies and meta information to allow
usage by repository reference.

Fixes #214 